### PR TITLE
Move trigger construction into `triggers/` directory

### DIFF
--- a/functions/create_welcome_message.ts
+++ b/functions/create_welcome_message.ts
@@ -3,6 +3,7 @@ import { DefineFunction, Schema, SlackFunction } from "deno-slack-sdk/mod.ts";
 
 import { SendWelcomeMessageWorkflow } from "../workflows/send_welcome_message.ts";
 import { WelcomeMessageDatastore } from "../datastores/messages.ts";
+import { newSendWelcomeMessageTrigger } from "../triggers/send_welcome_message_event.ts";
 
 /**
  * This custom function will take the initial form input, store it
@@ -60,7 +61,12 @@ export default SlackFunction(
 
     // Create a new user_joined_channel trigger if none exist
     if (!triggers.exists) {
-      const newTrigger = await saveUserJoinedChannelTrigger(client, channel);
+      const sendWelcomeMessageTrigger = newSendWelcomeMessageTrigger(channel);
+
+      const newTrigger = await client.workflows.triggers.create<
+        typeof SendWelcomeMessageWorkflow.definition
+      >(sendWelcomeMessageTrigger);
+
       if (!newTrigger.ok) {
         return {
           error: `Failed to create welcome trigger: ${newTrigger.error}`,
@@ -98,36 +104,4 @@ export async function findUserJoinedChannelTrigger(
   // Return if any matching triggers were found
   const exists = joinedTriggers.length > 0;
   return { exists };
-}
-
-/**
- * saveUserJoinedChannelTrigger creates a new user_joined_channel trigger
- * for the "Send Welcome Message" workflow in a channel.
- */
-export async function saveUserJoinedChannelTrigger(
-  client: SlackAPIClient,
-  channel: string,
-): Promise<{ ok: boolean; error?: string }> {
-  const triggerResponse = await client.workflows.triggers.create<
-    typeof SendWelcomeMessageWorkflow.definition
-  >({
-    type: "event",
-    name: "User joined channel",
-    description: "Send a message when a user joins the channel",
-    workflow:
-      `#/workflows/${SendWelcomeMessageWorkflow.definition.callback_id}`,
-    event: {
-      event_type: "slack#/events/user_joined_channel",
-      channel_ids: [channel],
-    },
-    inputs: {
-      channel: { value: channel },
-      triggered_user: { value: "{{data.user_id}}" },
-    },
-  });
-
-  if (!triggerResponse.ok) {
-    return { ok: false, error: triggerResponse.error };
-  }
-  return { ok: true };
 }

--- a/triggers/send_welcome_message_event.ts
+++ b/triggers/send_welcome_message_event.ts
@@ -1,0 +1,26 @@
+import { Trigger } from "deno-slack-api/types.ts";
+import { SendWelcomeMessageWorkflow } from "../workflows/send_welcome_message.ts";
+
+/**
+ * newSendWelcomeMessageTrigger constructs a new user_joined_channel trigger
+ * for the "Send Welcome Message" workflow in a specified channel.
+ */
+export function newSendWelcomeMessageTrigger(
+  channel: string,
+): Trigger<typeof SendWelcomeMessageWorkflow.definition> {
+  return {
+    type: "event",
+    name: "User joined channel",
+    description: "Send a message when a user joins the channel",
+    workflow:
+      `#/workflows/${SendWelcomeMessageWorkflow.definition.callback_id}`,
+    event: {
+      event_type: "slack#/events/user_joined_channel",
+      channel_ids: [channel],
+    },
+    inputs: {
+      channel: { value: channel },
+      triggered_user: { value: "{{data.user_id}}" },
+    },
+  };
+}


### PR DESCRIPTION
### Type of change

- [ ] New sample
- [ ] New feature
- [ ] Bug fix
- [ ] Documentation

### Summary

This PR follows from [this conversation](https://github.com/slack-samples/deno-welcome-bot/pull/13#discussion_r1102345383) and relocates trigger definition logic into the `triggers/` directory. This approach brings a few questions since this is a trigger created at runtime with dynamic inputs, while definitions in this directory are often static or created via the CLI.

This is only one approach for making this change. An alternative might move the entire creation process (including the API call) into the trigger definition file. Another may use a complete definition with blank inputs in place of the dynamic `channel` value, and populate these values from the custom function. I'm sure there are other ways to dice this too!

#### Open questions and thoughts

- Overall, I do agree that it makes sense to keep trigger definitions in this directory. Wondering if this might expand to other trigger logic, such as the `findUserJoinedChannelTrigger`, which is unique to the `SendWelcomeMessage` workflow's event trigger in this app?
- This trigger definition has dynamic inputs and therefore cannot be created using the CLI. Locating the definition in this directory may result in confused creations from the auto-creation prompt when first installing an app to a workspace.
- A previous example of defining a trigger in the `triggers/` directory that is also created at runtime can be found in the deno-simple-survey repo ([trigger definition](https://github.com/slack-samples/deno-simple-survey/blob/main/triggers/prompt_survey_trigger.ts), [trigger creation](https://github.com/slack-samples/deno-simple-survey/blob/main/functions/utils/trigger_operations.ts#L64)).
  - This repo also has examples of creating triggers by definition in functions [here](https://github.com/slack-samples/deno-simple-survey/blob/main/functions/create_survey_trigger.ts#L42) and [here](https://github.com/slack-samples/deno-simple-survey/blob/main/functions/create_prompt_trigger.ts#L44). These triggers also require dynamic inputs. Whatever decision is landed on here should probably be applied to this sample as well.
- Is there another approach of defining the trigger then populating the `channel_id` values that might be better?

### Requirements

- [x] I’ve checked my submission against the Samples Checklist to ensure it complies with all standards
- [x] I have ensured the changes I am contributing align with existing patterns and have tested and linted my code
- [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct)
